### PR TITLE
Fix/UI setting

### DIFF
--- a/client/src/atoms/fullpageState.ts
+++ b/client/src/atoms/fullpageState.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const fullpageState = atom<boolean>(false);

--- a/client/src/atoms/toastState.ts
+++ b/client/src/atoms/toastState.ts
@@ -1,0 +1,17 @@
+import { atom } from "jotai";
+
+export type ToastTheme = "negative" | "positive";
+
+interface ToastType {
+  isOpen: boolean;
+  theme: ToastTheme;
+  content: string;
+}
+
+export const toastState = atom<ToastType>({
+  isOpen: false,
+  theme: "positive",
+  content: "",
+});
+
+export const toastTransitionState = atom<boolean>(false);

--- a/client/src/components/Layouts/Frame/index.tsx
+++ b/client/src/components/Layouts/Frame/index.tsx
@@ -60,7 +60,7 @@ const Frame = ({ children, ...props }: FrameProps) => {
   return (
     <div css={[backgroundStyle, getBgColor(router.pathname)]} {...props}>
       <FrameHeader />
-      <Container css={getPaddingStyle(router.pathname)}>{children}</Container>
+      <Container css={[getPaddingStyle(router.pathname)]}>{children}</Container>
       <FrameNavigator />
     </div>
   );

--- a/client/src/components/Layouts/Frame/index.tsx
+++ b/client/src/components/Layouts/Frame/index.tsx
@@ -7,6 +7,7 @@ import styled from '@emotion/styled';
 import FrameNavigator from './FrameNavigator';
 import { COLORS } from '@/styles/colors';
 import { useRouter } from 'next/router';
+import { containerStyle } from '@/styles/tokens';
 
 interface FrameProps extends ComponentProps<'div'> {
   children: React.ReactNode;
@@ -42,10 +43,24 @@ const Frame = ({ children, ...props }: FrameProps) => {
     }
   };
 
+  const getPaddingStyle = (pathname: string) => {
+    switch (pathname) {
+      case '/landing':
+        return containerStyle.skinight;
+      case '/':
+      case '/template':
+      case '/mate':
+      case '/schedule':
+        return containerStyle.navigator;
+      default:
+        return containerStyle.header;
+    }
+  };
+
   return (
     <div css={[backgroundStyle, getBgColor(router.pathname)]} {...props}>
       <FrameHeader />
-      <Container>{children}</Container>
+      <Container css={getPaddingStyle(router.pathname)}>{children}</Container>
       <FrameNavigator />
     </div>
   );

--- a/client/src/components/Layouts/Header/NavHeader.tsx
+++ b/client/src/components/Layouts/Header/NavHeader.tsx
@@ -33,6 +33,8 @@ const HeaderWrapper = styled.div`
   top: 0px;
   left: 50%;
   ${transform('translate(-50%, 0%)')};
+  background-color: ${COLORS.white};
+  z-index: 10;
 
   box-shadow: 0px 1px 1px 0px rgba(0, 0, 0, 0.1);
 

--- a/client/src/components/Layouts/Header/NavHeader.tsx
+++ b/client/src/components/Layouts/Header/NavHeader.tsx
@@ -1,6 +1,6 @@
 import { mq } from '@/styles/breakpoints';
 import { COLORS } from '@/styles/colors';
-import { flex, transform } from '@/styles/tokens';
+import { HEADER_HEIGHT, flex, transform } from '@/styles/tokens';
 import { TYPO } from '@/styles/typo';
 import styled from '@emotion/styled';
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
@@ -28,7 +28,7 @@ const NavHeader = ({ title, onBack, ...props }: Props) => {
 const HeaderWrapper = styled.div`
   width: 100%;
   min-width: 32rem;
-  height: 6rem;
+  height: ${HEADER_HEIGHT}rem;
   position: fixed;
   top: 0px;
   left: 50%;
@@ -37,10 +37,6 @@ const HeaderWrapper = styled.div`
   z-index: 10;
 
   box-shadow: 0px 1px 1px 0px rgba(0, 0, 0, 0.1);
-
-  ${mq[4]} {
-    height: 5rem;
-  }
 `;
 
 const HeaderInner = styled.div`

--- a/client/src/components/Layouts/Header/TitleHeader.tsx
+++ b/client/src/components/Layouts/Header/TitleHeader.tsx
@@ -41,6 +41,8 @@ const HeaderWrapper = styled.div`
   top: 0px;
   left: 50%;
   ${transform('translate(-50%, 0%)')};
+  background-color: ${COLORS.white};
+  z-index: 10;
 
   box-shadow: 0px 1px 1px 0px rgba(0, 0, 0, 0.1);
   padding: 0rem 2.7rem;

--- a/client/src/components/Layouts/Header/TitleHeader.tsx
+++ b/client/src/components/Layouts/Header/TitleHeader.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { TYPO } from '@/styles/typo';
 import { COLORS } from '@/styles/colors';
-import { flex, transform } from '@/styles/tokens';
+import { HEADER_HEIGHT, flex, transform } from '@/styles/tokens';
 import HumanIcon from '@/assets/svg/human.svg';
 import { css } from '@emotion/react';
 import { mq } from '@/styles/breakpoints';
@@ -35,7 +35,7 @@ const hovering = css`
 const HeaderWrapper = styled.div`
   width: 100%;
   min-width: 32rem;
-  height: 6rem;
+  height: ${HEADER_HEIGHT}rem;
   ${flex('row', 'between', 'center', 0)};
   position: fixed;
   top: 0px;
@@ -46,10 +46,6 @@ const HeaderWrapper = styled.div`
 
   box-shadow: 0px 1px 1px 0px rgba(0, 0, 0, 0.1);
   padding: 0rem 2.7rem;
-
-  ${mq[4]} {
-    height: 5rem;
-  }
 `;
 
 const Logo = styled.span`

--- a/client/src/components/Layouts/Navigator/index.tsx
+++ b/client/src/components/Layouts/Navigator/index.tsx
@@ -66,6 +66,8 @@ const NavigatorWrapper = styled.div`
   min-width: 25rem;
   height: 7rem;
   ${flex('row', 'center', 'center', 0)};
+  background-color: ${COLORS.white};
+  z-index: 10;
 
   position: fixed;
   bottom: 0px;

--- a/client/src/components/Layouts/Navigator/index.tsx
+++ b/client/src/components/Layouts/Navigator/index.tsx
@@ -1,5 +1,5 @@
 import { COLORS } from '@/styles/colors';
-import { flex, transform } from '@/styles/tokens';
+import { BOTTOM_HEIGHT, flex, transform } from '@/styles/tokens';
 import { TYPO } from '@/styles/typo';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -64,7 +64,7 @@ const Navigator = ({ curRoute, handleRoute }: Props) => {
 const NavigatorWrapper = styled.div`
   width: 100%;
   min-width: 25rem;
-  height: 7rem;
+  height: ${BOTTOM_HEIGHT}rem;
   ${flex('row', 'center', 'center', 0)};
   background-color: ${COLORS.white};
   z-index: 10;

--- a/client/src/components/Layouts/ToastProvider/Toast.stories.tsx
+++ b/client/src/components/Layouts/ToastProvider/Toast.stories.tsx
@@ -1,0 +1,33 @@
+import type { StoryObj } from '@storybook/react';
+import ToastBox from './ToastBox';
+
+const meta = {
+  title: 'Layout/ToastBox',
+  component: ToastBox,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    theme: 'positive',
+    content: '임시 토스트 메시지입니다.',
+  },
+};
+
+export const Positive: Story = {
+  args: {
+    theme: 'positive',
+    content: '임시 토스트 메시지입니다.',
+  },
+};
+
+export const Negative: Story = {
+  args: {
+    theme: 'negative',
+    content: '임시 토스트 메시지입니다.',
+  },
+};

--- a/client/src/components/Layouts/ToastProvider/ToastBox.tsx
+++ b/client/src/components/Layouts/ToastProvider/ToastBox.tsx
@@ -1,0 +1,69 @@
+import { ToastTheme } from '@/atoms/toastState';
+import { COLORS } from '@/styles/colors';
+import { TYPO } from '@/styles/typo';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+interface Props {
+  /**
+   * 토스트 테마
+   */
+  theme: ToastTheme;
+  /**
+   * 글 내용
+   */
+  content: string;
+}
+
+/**
+ * 커스텀 Alert입니다.
+ */
+const ToastBox = ({ theme, content }: Props) => {
+  return (
+    <ToastInnerWrapper>
+      <ToastContent>{content}</ToastContent>
+      <ToastThemeLine css={toastStyles[theme]} />
+    </ToastInnerWrapper>
+  );
+};
+
+const ToastInnerWrapper = styled.div`
+  width: 32rem;
+  padding: 1.5rem 2rem;
+  border-radius: 0.5rem;
+  text-align: start;
+  white-space: pre-line;
+
+  background-color: ${COLORS.white};
+
+  position: relative;
+  overflow: hidden;
+  box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
+`;
+
+const ToastContent = styled.span`
+  ${TYPO.text2.Reg};
+  color: ${COLORS.grey2};
+  white-space: pre-line;
+  text-align: start;
+  line-height: 150%;
+`;
+
+const ToastThemeLine = styled.div`
+  width: 0.7rem;
+  height: 100%;
+  position: absolute;
+  top: 0px;
+  right: 0px;
+`;
+
+const toastStyles = {
+  positive: css`
+    background-color: ${COLORS.primary};
+  `,
+  negative: css`
+    background-color: ${COLORS.negative};
+  `,
+};
+
+export default ToastBox;

--- a/client/src/components/Layouts/ToastProvider/index.tsx
+++ b/client/src/components/Layouts/ToastProvider/index.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+import { transform } from '@/styles/tokens';
+import { useToast } from '@/hooks';
+import { injectAnimation } from '@/styles/animations';
+import ToastBox from './ToastBox';
+
+const Toast = () => {
+  const { isMount, theme, content, isTransition } = useToast();
+
+  if (isMount) {
+    return (
+      <ToastContainer
+        css={isTransition && injectAnimation('toastClose', '1s', 'ease')}
+      >
+        <ToastBox theme={theme} content={content} />
+      </ToastContainer>
+    );
+  }
+  return <></>;
+};
+
+const ToastContainer = styled.div`
+  position: fixed;
+  z-index: 99;
+  top: 2rem;
+  left: 50%;
+  opacity: 0;
+  ${transform('translate(-50%, 0%)')};
+  ${injectAnimation('toastOpen', '1s', 'ease')};
+`;
+
+export default Toast;

--- a/client/src/components/Layouts/index.tsx
+++ b/client/src/components/Layouts/index.tsx
@@ -2,3 +2,4 @@ export { default as Navigator } from './Navigator';
 export { default as Picker } from './Picker';
 export { default as Title } from './Title';
 export { default as Frame } from './Frame';
+export { default as ToastProvider } from './ToastProvider';

--- a/client/src/hooks/index.tsx
+++ b/client/src/hooks/index.tsx
@@ -2,3 +2,4 @@ export { default as useVh } from './useVh';
 export { default as useHeader } from './useHeader';
 export { default as useInput } from './useInput';
 export { default as useAuth } from './useAuth';
+export { default as useToast } from './useToast';

--- a/client/src/hooks/useAuth.tsx
+++ b/client/src/hooks/useAuth.tsx
@@ -4,12 +4,14 @@ import { getUserInfo, updateUserInfo } from '@/utils/lib/infoHandler';
 import { updateAccessToken } from '@/utils/lib/tokenHandler';
 import { useAtom } from 'jotai';
 import { useRouter } from 'next/router';
+import { useState } from 'react';
 
 const useAuth = () => {
   const authApi = new AuthApi();
 
   const router = useRouter();
   const [authInfo, setAuthInfo] = useAtom(authInfoState);
+  const [isWarn, setIsWarn] = useState(false);
 
   /**
    * 로그인 함수
@@ -24,8 +26,10 @@ const useAuth = () => {
       });
       updateAccessToken(data.accessToken);
       updateUserInfo(data.name, data.printMemberNo, id, password);
+      setIsWarn(false);
       router.replace('/');
     } catch (err) {
+      setIsWarn(true);
       console.log(err);
     }
   };
@@ -56,7 +60,7 @@ const useAuth = () => {
     }
   };
 
-  return { authInfo, autoLogin, handleLogin };
+  return { authInfo, autoLogin, handleLogin, isWarn };
 };
 
 export default useAuth;

--- a/client/src/hooks/useAuth.tsx
+++ b/client/src/hooks/useAuth.tsx
@@ -5,9 +5,11 @@ import { updateAccessToken } from '@/utils/lib/tokenHandler';
 import { useAtom } from 'jotai';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
+import { useToast } from '.';
 
 const useAuth = () => {
   const authApi = new AuthApi();
+  const { showToast } = useToast();
 
   const router = useRouter();
   const [authInfo, setAuthInfo] = useAtom(authInfoState);
@@ -27,9 +29,11 @@ const useAuth = () => {
       updateAccessToken(data.accessToken);
       updateUserInfo(data.name, data.printMemberNo, id, password);
       setIsWarn(false);
+      showToast('positive', '로그인에 성공하였습니다.');
       router.replace('/');
     } catch (err) {
       setIsWarn(true);
+      showToast('negative', '로그인에 실패하였습니다.\n다시 시도해주세요!');
       console.log(err);
     }
   };

--- a/client/src/hooks/useToast.tsx
+++ b/client/src/hooks/useToast.tsx
@@ -1,0 +1,59 @@
+import {
+  ToastTheme,
+  toastState,
+  toastTransitionState,
+} from '@/atoms/toastState';
+import { useAtom } from 'jotai';
+import { useEffect } from 'react';
+
+const useToast = () => {
+  const [toast, setToast] = useAtom(toastState);
+  const [isTransition, setIsTransition] = useAtom(toastTransitionState);
+  let timeoutId: NodeJS.Timeout | null = null;
+
+  const showToast = (theme: ToastTheme, content: string, delay = 3000) => {
+    if (toast.isOpen) return;
+    setToast({ isOpen: true, theme, content });
+    setTimeout(() => {
+      closeToast();
+    }, delay);
+  };
+
+  const handleUnmount = () => {
+    setToast((prev) => {
+      return {
+        ...prev,
+        isOpen: false,
+      };
+    });
+  };
+
+  const closeToast = (delay = 1000) => {
+    if (isTransition) return;
+
+    setIsTransition(true);
+    timeoutId = setTimeout(() => {
+      setIsTransition(false);
+      handleUnmount();
+    }, delay);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, []);
+
+  return {
+    showToast,
+    closeToast,
+    isMount: toast.isOpen,
+    theme: toast.theme,
+    content: toast.content,
+    isTransition,
+  };
+};
+
+export default useToast;

--- a/client/src/hooks/useVh.tsx
+++ b/client/src/hooks/useVh.tsx
@@ -10,8 +10,15 @@ const useVh = () => {
     setVh(vh);
   };
 
-  const remToPx = (rem: number) =>
-    parseFloat(getComputedStyle(document.documentElement).fontSize) * rem;
+  const remToPx = (rem: number) => {
+    if (typeof window !== 'undefined') {
+      return (
+        parseFloat(getComputedStyle(document.documentElement).fontSize) * rem
+      );
+    } else {
+      return 10 * rem;
+    }
+  };
 
   const fullPageHeight = useCallback(
     (headerHeight = 0, navigatorHeight = 0) => {

--- a/client/src/hooks/useVh.tsx
+++ b/client/src/hooks/useVh.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 /** 리사이징 이벤트에 따라 변하는 vh 가져오는 훅 (불필요한 스크롤 생기는 이슈 방지) */
 const useVh = () => {
@@ -10,12 +10,24 @@ const useVh = () => {
     setVh(vh);
   };
 
-  const fullPageStyle = useMemo(
-    () => css`
-      width: 100%;
-      height: calc(${vh}px * 100);
-    `,
+  const remToPx = (rem: number) =>
+    parseFloat(getComputedStyle(document.documentElement).fontSize) * rem;
+
+  const fullPageHeight = useCallback(
+    (headerHeight = 0, navigatorHeight = 0) => {
+      const headerHeightPx = remToPx(headerHeight);
+      const navigatorHeightPx = remToPx(navigatorHeight);
+      return `calc(${vh}px * 100 - ${headerHeightPx}px - ${navigatorHeightPx}px)`;
+    },
     [vh],
+  );
+
+  const fullPageStyle = useCallback(
+    (headerHeight = 0, navigatorHeight = 0) => css`
+      width: 100%;
+      height: ${fullPageHeight(headerHeight, navigatorHeight)};
+    `,
+    [fullPageHeight],
   );
 
   useEffect(() => {

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -1,6 +1,6 @@
 import type { AppProps } from 'next/app';
 import '@fortawesome/fontawesome-svg-core/styles.css';
-import { Frame } from '@/components/Layouts';
+import { Frame, ToastProvider } from '@/components/Layouts';
 import useAuth from '@/hooks/useAuth';
 import { useEffect } from 'react';
 import { Global, css } from '@emotion/react';
@@ -31,6 +31,7 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <QueryClientProvider client={queryClient}>
       <Frame>
+        <ToastProvider />
         <Global styles={[reset, getBgColor(router.pathname)]} />
         <Component {...pageProps} />
       </Frame>

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -21,7 +21,7 @@ const Landing = () => {
   };
 
   return (
-    <Container css={fullPageStyle}>
+    <Container css={fullPageStyle()}>
       <TitleWrapper>
         <span css={TYPO.title1.Eb}>SSUDOBI</span>
         <span css={TYPO.title2.Reg}>숭실대학교 도서관 비대면 예약 시스템</span>

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -2,7 +2,7 @@ import { RoundButton } from '@/components/Buttons';
 import { TextInput } from '@/components/Field';
 import { useAuth, useHeader, useInput, useVh } from '@/hooks';
 import { COLORS } from '@/styles/colors';
-import { flex } from '@/styles/tokens';
+import { HEADER_HEIGHT, flex } from '@/styles/tokens';
 import { TYPO } from '@/styles/typo';
 import styled from '@emotion/styled';
 import { useLayoutEffect } from 'react';
@@ -26,7 +26,7 @@ const Login = () => {
   }, []);
 
   return (
-    <Container css={fullPageStyle(6)}>
+    <Container css={fullPageStyle(HEADER_HEIGHT)}>
       <InputWrapper>
         <InputBox>
           <Caption>학번</Caption>

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -26,7 +26,7 @@ const Login = () => {
   }, []);
 
   return (
-    <Container css={fullPageStyle}>
+    <Container css={fullPageStyle(6)}>
       <InputWrapper>
         <InputBox>
           <Caption>학번</Caption>
@@ -65,7 +65,7 @@ const Login = () => {
 
 const Container = styled.div`
   width: 100%;
-  padding: 12rem 4.5rem;
+  padding: 9rem 4.5rem;
   ${flex('column', 'between', 'center', 5)};
 `;
 

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -18,7 +18,7 @@ type FormData = {
 const Login = () => {
   const { setHeader } = useHeader();
   const { fullPageStyle } = useVh();
-  const { handleLogin } = useAuth();
+  const { handleLogin, isWarn } = useAuth();
   const { values, handleChange } = useInput<FormData>({ id: '', password: '' });
 
   useLayoutEffect(() => {
@@ -35,6 +35,7 @@ const Login = () => {
             value={values.id}
             name="id"
             onChange={handleChange}
+            warning={isWarn}
           />
         </InputBox>
         <InputBox>
@@ -45,6 +46,8 @@ const Login = () => {
             value={values.password}
             name="password"
             onChange={handleChange}
+            warning={isWarn}
+            warningCaption="학번 또는 비밀번호가 일치하지 않습니다."
           />
         </InputBox>
       </InputWrapper>

--- a/client/src/styles/animations.tsx
+++ b/client/src/styles/animations.tsx
@@ -100,6 +100,29 @@ const loginButtonPopup = keyframes`
   }
 `;
 
+const toastAnimations = {
+  open: keyframes`
+    0%{
+      opacity: 0;
+      ${transform('translate(-50%, -20%)')};
+    }
+    100%{
+      opacity: 1;
+      ${transform('translate(-50%, 0%)')};
+    }
+  `,
+  close: keyframes`
+    0%{
+      opacity: 1;
+      ${transform('translate(-50%, 0%)')};
+    }
+    100%{
+      opacity: 0;
+      ${transform('translate(-50%, -20%)')};
+    }
+  `,
+};
+
 const animations = {
   fadeInTopDown,
   fadeInTopDownTranslate,
@@ -108,6 +131,8 @@ const animations = {
   circleMovingBottom: circleMoving.bottom,
   loginTitlePopup,
   loginButtonPopup,
+  toastOpen: toastAnimations.open,
+  toastClose: toastAnimations.close,
 };
 
 export const injectAnimation = (

--- a/client/src/styles/colors.tsx
+++ b/client/src/styles/colors.tsx
@@ -5,6 +5,7 @@ export const COLORS = {
   grey0: '#0C0C0C',
   grey1: '#161616',
   grey2: '#444444',
+  grey25: '#6D6A64',
   grey3: '#999999',
   grey4: '#CCCCCC',
   grey5: '#D7D7D7',

--- a/client/src/styles/tokens.tsx
+++ b/client/src/styles/tokens.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import { mq } from './breakpoints';
 
 type Direction = 'row' | 'column';
 type JustifyContent =
@@ -68,5 +69,24 @@ export const transition = (duration: string, animationType = 'linear') => {
 
 export const PageContainer = styled.div`
   width: 100%;
-  padding: 1rem 2.7rem;
+  min-height: 100%;
 `;
+
+export const containerStyle = {
+  navigator: css`
+    padding-top: 6rem;
+    padding-bottom: 7rem;
+    ${mq[4]} {
+      padding-top: 5rem;
+    }
+  `,
+  header: css`
+    padding-top: 6rem;
+    ${mq[4]} {
+      padding-top: 5rem;
+    }
+  `,
+  skinight: css`
+    padding: 0rem;
+  `,
+};

--- a/client/src/styles/tokens.tsx
+++ b/client/src/styles/tokens.tsx
@@ -72,19 +72,18 @@ export const PageContainer = styled.div`
   min-height: 100%;
 `;
 
+/** 공통 헤더 높이 */
+export const HEADER_HEIGHT = 6;
+/** 공통 바텀 네비게이션바 높이 */
+export const BOTTOM_HEIGHT = 7;
+
 export const containerStyle = {
   navigator: css`
-    padding-top: 6rem;
-    padding-bottom: 7rem;
-    ${mq[4]} {
-      padding-top: 5rem;
-    }
+    padding-top: ${HEADER_HEIGHT}rem;
+    padding-bottom: ${BOTTOM_HEIGHT}rem;
   `,
   header: css`
-    padding-top: 6rem;
-    ${mq[4]} {
-      padding-top: 5rem;
-    }
+    padding-top: ${HEADER_HEIGHT}rem;
   `,
   skinight: css`
     padding: 0rem;


### PR DESCRIPTION
## Issue

> **하나의 PR에 하나 이상의 이슈**가 존재해야합니다.

[UI 규격화](https://www.notion.so/UI-d6d57ce6cb594fadba7babfd13ad5faf?pvs=4)

## Description

- 로그인 실패시 워닝
- **중요** 헤더와 중앙 콘테이너 사이의 규격을 정확하게 맞추어놨습니다.
  - 만약, 해당 페이지가 스크롤이 없는 꽉 찬 페이지를 원한다면 `useVh`의 `fullPageStyle`을 이용해주세요.
  ```typescript
  //헤더와 네비게이션 바가 있는 페이지의 경우, 해당 페이지 최 상단 Element css에 아래 삽입
  fullPageStyle(HEADER_HEIGHT, BOTTOM_HEIGHT);
  
  //헤더만 있는 페이지의 경우, 해당 페이지 최 상단 Element css에 아래 삽입
  fullPageStyle(HEADER_HEIGHT);
  
  //아무 레이아웃이 없는 페이지의 경우, 해당 페이지 최 상단 Element css에 아래 삽입
  fullPageStyle();
  ```
  - 정확한 사용 예시가 궁금하다면 [이 부분](https://github.com/gdsc-ssu/ssudobi-refactor/blob/35693d7b172e4c996d86bdc3b82a0c299bf664d1/client/src/pages/login.tsx)을 봐주세요
- **중요** 토스트 메시지 프로바이더를 추가해놨습니다.
  - 두 개의 테마가 존재하며, 구체적인 사항은 스토리북 확인해주세요!
  - `useToast`를 호출하고, 실행을 원하는 스코프에서 `showToast`를 호출해주세요.
  - `showToast(theme, content, delay)`이며, `theme`의 경우에는 `positive`와 `negative`로 나뉩니다.
  - `delay`는 기본값이 설정되어있습니다. 특별한 상황이 아니라면 따로 설정하지 않는 것을 추천합니다. (애니메이션 고려)

## Check List

- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] 작업한 사람 모두를 Assign
- [x] Code Review 요청
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
