### PR TITLE
fix: reserve ui & reserve default name

### DIFF
--- a/client/src/components/BottomModal/ConfirmReservationModal/index.tsx
+++ b/client/src/components/BottomModal/ConfirmReservationModal/index.tsx
@@ -52,6 +52,7 @@ interface ConfirmReservationModalProps {
   setIsError: Dispatch<SetStateAction<ReserveError>>;
   // 템플릿용인지 예약용인지
   createType: 'template' | 'reserve';
+  handleClose?: () => void;
 }
 
 const ConfirmReservationModal = ({
@@ -66,6 +67,7 @@ const ConfirmReservationModal = ({
   setIsSuccess,
   setIsError,
   createType,
+  handleClose,
 }: ConfirmReservationModalProps) => {
   const { template, settingReservationInfo } = useTemplate();
 
@@ -153,12 +155,14 @@ const ConfirmReservationModal = ({
               .then((res) => {
                 if (res.success) {
                   setIsSuccess(true);
+                  if (handleClose) handleClose();
                 } else {
                   setIsError({ isError: true, errorMessage: res.message });
                 }
               });
           } else {
             setIsSuccess(true);
+            if (handleClose) handleClose();
           }
         }}
       >

--- a/client/src/components/ReservationCheck/ReservationItem.tsx
+++ b/client/src/components/ReservationCheck/ReservationItem.tsx
@@ -97,8 +97,8 @@ const ReservationItem = ({
         <Modal
           isTransition={isTransition}
           modalType="decision"
-          title={title}
-          message="예약을 정말 삭제할까요?"
+          title="예약을 정말 삭제할까요?"
+          message="삭제한 예약은 복구할 수 없어요."
           handleClose={handleClose}
           onClick={handleRemove}
         />

--- a/client/src/components/ReservationCheck/index.tsx
+++ b/client/src/components/ReservationCheck/index.tsx
@@ -40,7 +40,7 @@ const ReservationCheck = () => {
           reservationData?.data?.list.map((el, idx) => (
             <ListBox key={idx}>
               <ReservationItem
-                title="외부 예약"
+                title="예약 완료"
                 beginTime={el.beginTime}
                 endTime={el.endTime}
                 room={el.room.name}

--- a/client/src/components/TemplateList/TemplatePage/Template.tsx
+++ b/client/src/components/TemplateList/TemplatePage/Template.tsx
@@ -22,6 +22,7 @@ import { WeekdayShort } from 'Template';
 import ConfirmModal from '@/components/Modal/Confrim';
 import { useRouter } from 'next/router';
 import * as bottomStyles from '@/components/BottomModal/ReserveConfirm';
+import ReactPortal from '@/components/Modal/Portal';
 
 type ModalType = 'remove' | 'bottom' | 'confirm';
 
@@ -199,45 +200,50 @@ const Template = ({
         />
       )}
       {isMount && modalType === 'bottom' && (
-        <bottomStyles.Modal
-          css={
-            isTransition &&
-            injectAnimation('modalBackgroundDisappear', '0.4s', 'ease')
-          }
-          onClick={handleClose}
-        >
-          <bottomStyles.ModalView
-            height="500px"
-            style={{ marginBottom: '63px' }}
+        <ReactPortal wrapperId="modal-bottom-sheet">
+          <bottomStyles.Modal
             css={
-              isTransition && injectAnimation('modalDisappear', '0.4s', 'ease')
+              isTransition &&
+              injectAnimation('modalBackgroundDisappear', '0.4s', 'ease')
             }
-            onClick={(e) => {
-              e.stopPropagation();
-            }}
+            onClick={handleClose}
           >
-            <ConfirmReservationModal
-              slotDay={formatOnlyDate(date)}
-              day={selectedTemplate.day}
-              date={date.slice(0, 10)}
-              startTime={beginTime}
-              endTime={endTime}
-              companions={companions}
-              seminaRoom={selectedTemplate.semina.map((item) => `${item}`)}
-              type={typeNumber.indexOf(selectTemplate![0].type)}
-              setIsSuccess={setIsSuccess}
-              setIsError={setIsError}
-              createType="reserve"
-            />
-          </bottomStyles.ModalView>
-        </bottomStyles.Modal>
+            <bottomStyles.ModalView
+              height="500px"
+              css={
+                isTransition &&
+                injectAnimation('modalDisappear', '0.4s', 'ease')
+              }
+              onClick={(e) => {
+                e.stopPropagation();
+              }}
+            >
+              <ConfirmReservationModal
+                slotDay={formatOnlyDate(date)}
+                day={selectedTemplate.day}
+                date={date.slice(0, 10)}
+                startTime={beginTime}
+                endTime={endTime}
+                companions={companions}
+                seminaRoom={selectedTemplate.semina.map((item) => `${item}`)}
+                type={typeNumber.indexOf(selectTemplate![0].type)}
+                setIsSuccess={setIsSuccess}
+                setIsError={setIsError}
+                createType="reserve"
+                handleClose={handleClose}
+              />
+            </bottomStyles.ModalView>
+          </bottomStyles.Modal>
+        </ReactPortal>
       )}
       {isSuccess && (
-        <ConfirmModal
-          onClick={handleReserveSuccess}
-          title="예약이 완료되었습니다."
-          message="예약 정보는 스케줄 탭에서 확인하세요!"
-        />
+        <ReactPortal wrapperId="confirm-success-modal">
+          <ConfirmModal
+            onClick={handleReserveSuccess}
+            title="예약이 완료되었습니다."
+            message="예약 정보는 스케줄 탭에서 확인하세요!"
+          />
+        </ReactPortal>
       )}
     </>
   );


### PR DESCRIPTION
## Issue

> **하나의 PR에 하나 이상의 이슈**가 존재해야합니다.

[이슈 제목]()

## Description

템플릿에서 예약하기 할 때 지난 회의 때 이야기한대로 UI 수정하였고,
'외부 예약'으로 나타나던 이름은 우선 '예약 완료' 느낌으로 변경해두었습니다.

## Check List

- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] 작업한 사람 모두를 Assign
- [x] Code Review 요청
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
